### PR TITLE
FIX: font path had extra directory

### DIFF
--- a/MX_Sline/usr/share/enigma2/MX_Sline/skin.xml
+++ b/MX_Sline/usr/share/enigma2/MX_Sline/skin.xml
@@ -79,8 +79,8 @@ Pls Read skin info
     <color name="yellow" value="#00bab329" />
   </colors>
   <fonts>
-    <font filename="MX_Sline/fonts/tiny.ttf" name="Regular" scale="100" />
-    <font filename="MX_Sline/fonts/tiny.ttf" name="Subtitlefont" scale="100" />
+    <font filename="fonts/tiny.ttf" name="Regular" scale="100" />
+    <font filename="fonts/tiny.ttf" name="Subtitlefont" scale="100" />
     <font filename="ae_AlMateen.ttf" name="Replacement" scale="100" replacement="1" />
     <font filename="tuxtxt.ttf" name="Console" scale="100" />
     <alias name="ChoiceList" font="Regular" size="28" height="35" />


### PR DESCRIPTION
This skin caused enigma2 crash too. Since first problem with Plugins descriptor was fixed. Here was still 2nd problem with font path:

```
<  4995.927> [FONT] adding font MX_Sline/fonts/tiny.ttf...[FONT] failed: Operation not permitted<  4995.927> Backtrace:
<  4995.928> enigma2(_Z17handleFatalSignaliP9siginfo_tPv) [0x2329C0]
<  4995.928> /lib/libc.so.6(__default_rt_sa_restorer) [0xB6C50DD0]
<  4995.928> -------FATAL SIGNAL
```

from strace output:
```
stat64("/etc/enigma2/fonts/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/etc/enigma2/MX_Sline/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/etc/enigma2/display/skin_default/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/etc/enigma2/skin_common/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/etc/enigma2/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/usr/share/enigma2/MX_Sline/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/usr/share/enigma2/skin_default/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/usr/share/enigma2/display/skin_default/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/usr/share/enigma2/display/skin_default/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("/usr/share/fonts/MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
stat64("MX_Sline/fonts/tiny.ttf", 0xbeb0b2a0) = -1 ENOENT (No such file or directory)
```

take look for part `/usr/share/enigma2/MX_Sline/MX_Sline/fonts/tiny.ttf`.. It tries look for subfolder named same as skin name...

so change was just remove redudant MX_Sline path

```
    <font filename="fonts/tiny.ttf" name="Regular" scale="100" />
    <font filename="fonts/tiny.ttf" name="Subtitlefont" scale="100" />
```